### PR TITLE
Adds the ability to use custom colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@ An easy way to generate papers using [fpdf](https://github.com/go-pdf/fpdf).
 
 ## Usage
 ```sh
-paper.gen -templ dotted -out dotted.pdf -format a3 -orientation landscape -color black
+paper.gen -templ dotted -out dotted.pdf -format a3 -orientation landscape -background-color 24273a -dot-color 494d64
 ```

--- a/cli/blank.go
+++ b/cli/blank.go
@@ -10,6 +10,7 @@ func generateBlank(outFile io.WriteCloser) error {
 	pdf, err := paper_generator.GenerateBlank(
 		format,
 		orientation,
+		backgroundColor,
 	)
 	if err != nil {
 		return err

--- a/cli/dotted.go
+++ b/cli/dotted.go
@@ -10,6 +10,7 @@ func generateDotted(outFile io.WriteCloser) error {
 	pdf, err := paper_generator.GenerateDotted(
 		format,
 		orientation,
+		backgroundColor,
 		dotColor,
 		dotDistance,
 		dotRadius,

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -11,6 +11,7 @@ import (
 
 var format = paper.A4
 var orientation = paper.Portrait
+var backgroundColor = paper.White
 var dotColor = paper.Gray
 var dotDistance = 5.0
 var dotRadius = 0.35
@@ -24,7 +25,8 @@ func Start() error {
 
 	flagFormat("format", "Format of the paper", &format)
 	flagOrientation("orientation", "Orientation of the paper", &orientation)
-	flagColor("color", "Dot color", &dotColor)
+	flagColor("background-color", "Background color", &backgroundColor)
+	flagColor("dot-color", "Dot color", &dotColor)
 	flagFloat64("distance", "Distance between dots", &dotDistance)
 	flagFloat64("radius", "Radius of a dot", &dotRadius)
 	flag.Parse()
@@ -80,13 +82,18 @@ func flagOrientation(name string, useage string, out *paper.Orientation) {
 func flagColor(name string, useage string, out *paper.Color) {
 	flag.Func(name, useage, func(value string) error {
 		color, ok := paper.Colors[value]
-		if !ok {
-			// TODO: Add support for HEX, RGB,...
-			return errors.New("unkown color")
+		if ok {
+			*out = color
+			return nil
 		}
 
-		*out = color
-		return nil
+		color, ok = paper.ColorFromString(value)
+		if ok {
+			*out = color
+			return nil
+		}
+
+		return errors.New("unkown color")
 	})
 }
 

--- a/paper/color.go
+++ b/paper/color.go
@@ -1,5 +1,10 @@
 package paper
 
+import (
+	"fmt"
+	"log"
+)
+
 var (
 	Colors = map[string]Color{
 		"black":     Black,
@@ -32,4 +37,16 @@ func (c Color) GreenInt() int {
 
 func (c Color) BlueInt() int {
 	return int(c.Blue)
+}
+
+func ColorFromString(s string) (Color, bool) {
+	c := Color{}
+
+	_, err := fmt.Sscanf(s, "%02x%02x%02x", &c.Red, &c.Green, &c.Blue)
+	if err != nil {
+		log.Printf("[ERROR]: %s", err.Error())
+		return c, false
+	}
+
+	return c, true
 }

--- a/paper_generator/blank.go
+++ b/paper_generator/blank.go
@@ -8,9 +8,20 @@ import (
 func GenerateBlank(
 	format paper.Format,
 	orientation paper.Orientation,
+	backgroundColor paper.Color,
 ) (*fpdf.Fpdf, error) {
 	pdf := format.NewFPDF(orientation)
 	pdf.AddPage()
+
+	pdf.SetFillColor(
+		backgroundColor.RedInt(),
+		backgroundColor.GreenInt(),
+		backgroundColor.BlueInt(),
+	)
+
+	width, height := pdf.GetPageSize()
+
+	pdf.Rect(0, 0, width, height, "F")
 
 	return pdf, nil
 }

--- a/paper_generator/dotted.go
+++ b/paper_generator/dotted.go
@@ -8,6 +8,7 @@ import (
 func GenerateDotted(
 	format paper.Format,
 	orientation paper.Orientation,
+	backgroundColor paper.Color,
 	dotColor paper.Color,
 	dotDistance float64,
 	dotRadius float64,
@@ -15,13 +16,22 @@ func GenerateDotted(
 	pdf := format.NewFPDF(orientation)
 
 	pdf.AddPage()
+
+	width, height := pdf.GetPageSize()
+
+	pdf.SetFillColor(
+		backgroundColor.RedInt(),
+		backgroundColor.GreenInt(),
+		backgroundColor.BlueInt(),
+	)
+
+	pdf.Rect(0, 0, width, height, "F")
+
 	pdf.SetFillColor(
 		dotColor.RedInt(),
 		dotColor.GreenInt(),
 		dotColor.BlueInt(),
 	)
-
-	width, height := pdf.GetPageSize()
 
 	for x := float64(0); x < width; x += dotDistance {
 		for y := float64(0); y < height; y += dotDistance {


### PR DESCRIPTION
You can now create papers with a custom foreground and background color.

Additionally to the usual colors already defined (`black`, `white`, etc.) you can now use your own colors defined in hex (`#24273a`, `#494d64`, etc.).

The colors have to be passed to the cli without the leading `#`.